### PR TITLE
Rewrite image creation, make easier to add more releases, rely less on mod_proxy_cluster testsuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Setup  performance tests
         run: sh setup.sh
       - name: Run performance tests
-        run: sh run.sh
+        run: sh run-suite.sh
       - name: Make a summary of test runs
         run: |
           perl summary.pl output/ | tee summary && cp summary output/summary-for-${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Get dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install moby-engine moby-cli gcc maven git curl iproute2 wcstools g++-12 cmake liblist-moreutils-perl
+          sudo apt-get install moby-engine moby-cli gcc maven git curl iproute2 wcstools g++ cmake liblist-moreutils-perl
       - name: Setup  performance tests
         run: sh setup.sh
       - name: Run performance tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	path = mod_cluster-testsuite
 	url = https://github.com/modcluster/mod_cluster
 [submodule "mod_cluster-1.3.x"]
-	path = mod_cluster-1.3.x
+	path = mod_proxy_cluster-1.3.x
 	url = https://github.com/modcluster/mod_cluster
 	branch = 1.3.x
 [submodule "demo-webapp"]

--- a/Containerfile
+++ b/Containerfile
@@ -6,10 +6,6 @@ ARG HTTPD_SOURCES="https://dlcdn.apache.org/httpd/httpd-2.4.65.tar.gz"
 
 ENV HTTPD=${HTTPD_SOURCES}
 
-# make sure you have copy of the local repository at place
-# (our function "httpd_create" takes care of that)
-COPY mod_proxy_cluster /
-
 ADD ${HTTPD} .
 
 RUN mkdir /httpd && tar xvf $(filename $HTTPD) --strip 1 -C /httpd
@@ -23,31 +19,36 @@ RUN ./configure --enable-proxy \
 RUN make
 RUN make install
 
+# make sure you have copy of the local repository at place
+# (our function "httpd_create" takes care of that)
+COPY native /native
+
 # httpd is installed in /usr/local/apache2/bin/
 # build and install mod_proxy_cluster *.so files.
-WORKDIR /native
-RUN mkdir build || true
-WORKDIR /native/build
-RUN cmake ../ -G "Unix Makefiles" -DAPACHE_INCLUDE_DIR=/usr/local/apache2/include/
-RUN make
-RUN cp modules/*.so /usr/local/apache2/modules/
-
-RUN rm -rf /test/httpd/mod_proxy_cluster
+RUN mkdir -p /native/build && \
+    cd /native/build && \
+    cmake ../ -G "Unix Makefiles" -DAPACHE_INCLUDE_DIR=/usr/local/apache2/include/ && \
+    make
+RUN cp /native/build/modules/*.so /usr/local/apache2/modules/
+# preserve the version
+RUN grep -rh "#define MOD_CLUSTER_EXPOSED_VERSION " /native > /mpc_version
 
 
 FROM fedora:42
 
-ENV CONF=httpd/mod_proxy_cluster.conf
+LABEL perfsuite-mod_proxy_cluster=
 
 RUN dnf install pcre apr-util wcstools -y
 
 COPY --from=builder /usr/local/apache2/ /usr/local/apache2
 
-COPY --from=builder /test /test
+COPY --from=builder /mpc_version /mpc_version
 
-COPY run.sh /tmp
+COPY mod_proxy_cluster.conf /usr/local/apache2/conf/
+
+COPY httpd-container-run.sh /
 
 WORKDIR /usr/local/apache2/
 
-CMD /tmp/run.sh
+CMD /httpd-container-run.sh
 

--- a/httpd-container-run.sh
+++ b/httpd-container-run.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# if version is 1.3.x then load slotmem and wstunnel
+if grep -q "1\.3\." /mpc_version
+then
+    sed -i 's|slotmem_shm_module.*modules/mod_slotmem_shm.so|cluster_slotmem_module modules/mod_cluster_slotmem.so|' conf/mod_proxy_cluster.conf
+    sed -i '8s|^|LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so\n|' conf/mod_proxy_cluster.conf
+fi
+
+# Include our mod_proxy_cluster.conf
+echo "Include conf/mod_proxy_cluster.conf" >> conf/httpd.conf
+
+echo "Starting httpd with $(sed -rn 's|.*\"(.*)\"|\1|p' /mpc_version)..."
+bin/apachectl start
+tail -f logs/error_log
+

--- a/local.sh
+++ b/local.sh
@@ -6,7 +6,7 @@ sh setup.sh
 for count in 2 10 20 50 ## 100 150
 do
     echo "Running for $count nodes"
-    TOMCAT_COUNT=$count sh run.sh
+    TOMCAT_COUNT=$count sh run-suite.sh
     sh summary.sh > summary-for-$count
     mkdir nodes-$count
     mv summary-for-$count output/* nodes-$count/

--- a/mod_proxy_cluster.conf
+++ b/mod_proxy_cluster.conf
@@ -1,0 +1,41 @@
+LoadModule watchdog_module      modules/mod_watchdog.so
+LoadModule proxy_module         modules/mod_proxy.so
+LoadModule proxy_http_module    modules/mod_proxy_http.so
+LoadModule proxy_hcheck_module  modules/mod_proxy_hcheck.so
+LoadModule slotmem_shm_module   modules/mod_slotmem_shm.so
+LoadModule manager_module       modules/mod_manager.so
+LoadModule proxy_cluster_module modules/mod_proxy_cluster.so
+
+
+UseAlias On
+ProxyPreserveHost On
+
+Listen 8090
+ServerName localhost
+WSUpgradeHeader websocket
+
+CreateBalancers 0
+EnableOptions On
+
+<VirtualHost *:8090>
+  EnableMCMPReceive
+  <Location />
+    Require ip 127.0.0.
+    Require ip ::1
+    # This one is used in GH Actions
+    Require ip 172.17.
+  </Location>
+  <Location /mod_cluster_manager>
+    SetHandler mod_cluster-manager
+    Require ip 127.0.0.
+    Require ip ::1
+    # This one is used in GH Actions
+    Require ip 172.17.
+  </Location>
+</VirtualHost>
+
+Maxnode 50
+ServerLimit 32
+StartServers 8
+MaxKeepAliveRequests 0
+

--- a/run-suite.sh
+++ b/run-suite.sh
@@ -91,9 +91,9 @@ disable_tomcats_randomly() {
     done
 }
 
-run_abtest_for() {
+run_tests_with() {
     if [ -z "$1" ]; then
-        echo "run_abtest_for requires httpd container name"
+        echo "run_tests_with requires httpd container name"
         exit 1
     fi
     # start httpd
@@ -140,9 +140,10 @@ run_abtest_for() {
     PAD=$(expr length "$REPETITIONS")
 
     # run tests with client or ab
+    version=$(get_version_from_image $i)
     for i in $(seq 1 $REPETITIONS)
     do
-        echo "Running $i/$REPETITIONS run for $1     ($(date))"
+        echo "Running $i/$REPETITIONS run for $version     ($(date))"
         ipadded=$(printf "%0${PAD}d" $i)
 
         # define RUN_WITH_AB to run the previously used `ab` utility; then instead of summary.sh use ab-summary.sh
@@ -187,6 +188,6 @@ httpd_remove
 
 for image in $(docker image ls --filter 'label=perfsuite-mod_proxy_cluster' --format {{.Repository}})
 do
-    run_abtest_for $image
+    run_tests_with $image
 done
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,35 +1,20 @@
 #!/usr/bin/sh
 
-export HTTPD_IMG_1_3=${HTTPD_IMG_1_3:-httpd-mod_proxy_cluster-1.3.x}
-export HTTPD_IMG_2_0=${HTTPD_IMG_2_0:-httpd-mod_proxy_cluster-2.x}
-export IMG=${IMG:-mod_proxy_cluster-testsuite-tomcat}
+# we'll build the tomcat image under our own name
+export IMG=${IMG:-mpc-perfsuite-tomcat}
 
 echo "Setting up dependencies"
 
-echo -n "Replacing tests from mod_proxy_cluster 1.3.x with tests from 2.x..."
-rm -rf mod_cluster-1.3.x/test/
-cp -r mod_proxy_cluster/test/ mod_cluster-1.3.x/test/
-cp Containerfile mod_cluster-1.3.x/test/httpd/
+# First build all the dependencies,
+# then go through all mod_proxy_cluster* directories
+# and build a container image for each of them
 
-sed -i 's|slotmem_shm_module.*modules/mod_slotmem_shm.so|cluster_slotmem_module modules/mod_cluster_slotmem.so|' mod_cluster-1.3.x/test/httpd/mod_proxy_cluster.conf
-sed -i '8s|^|LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so\n|' mod_cluster-1.3.x/test/httpd/mod_proxy_cluster.conf
-echo " Done"
-
-# Increase MaxNode to 50
-for conf_file in mod_proxy_cluster/test/httpd/mod_proxy_cluster.conf mod_cluster-1.3.x/test/httpd/mod_proxy_cluster.conf
-do
-    echo "Maxnode 50"          >> $conf_file
-    echo "ServerLimit 32"      >> $conf_file
-    echo "StartServers 8"      >> $conf_file
-    echo "MaxKeepAliveRequests 0" >> $conf_file
-    if [ $HTTPD_LOG_LEVEL ]; then
-        echo "Setting log level to $HTTPD_LOG_LEVEL"
-        echo "LogLevel $HTTPD_LOG_LEVEL" >> $conf_file
-    fi
-done
-
+#############################
+####  M I S C   A P P S  ####
+#############################
+# Maven installs for the applications used there
 echo -n "Running maven installs... "
-for m in httpd_websocket-testsuite/ mod_cluster-testsuite/ mod_proxy_cluster/test/ mod_cluster-1.3.x/test/ demo-webapp/
+for m in httpd_websocket-testsuite/ mod_cluster-testsuite/ mod_proxy_cluster/test/  demo-webapp/
 do
     cd $m
     mvn install
@@ -39,58 +24,64 @@ do
     fi
     cd $OLDPWD
 done
-
 echo "Done"
 
-echo -n "Creating httpd and tomcat images..."
+###########################
+####    T O M C A T    ####
+###########################
+# Create a tomcat container from the mod_proxy_cluster upstream testsuite
+echo -n "Creating httpd and tomcat images... "
 # First we'll change the default tomcat port from 8080 to 9000 so that we avoid conflicts
 # with the mod_proxy_cluster's port 8090 in case of 10 or more tomcat containers...
-sed -i -e 's/8080/9000/g' mod_proxy_cluster/test/includes/common.sh
-sed -i -e 's/8080/9000/g' mod_proxy_cluster/test/tomcat/server.xml
-
-# tomcat and httpd with mod_proxy_cluster 2.x
 cd mod_proxy_cluster/test/
+sed -i -e 's/8080/9000/g' includes/common.sh
+sed -i -e 's/8080/9000/g' tomcat/server.xml
 # load helper functions
 . includes/common.sh
-# tomcat
 tomcat_create
 if [ $? -ne 0 ]; then
     echo "Error occurred during tomcat image creation"
     exit 1
 fi
+cd $OLDPWD
+echo "Done"
 
-rm -rf httpd/mod_proxy_cluster /tmp/mod_proxy_cluster
-mkdir /tmp/mod_proxy_cluster
-cp -r ../native ../test /tmp/mod_proxy_cluster/
-mv /tmp/mod_proxy_cluster httpd/
-
-docker build -t $HTTPD_IMG_2_0 -f httpd/Containerfile httpd/
-if [ $? -ne 0 ]; then
-    echo "Error occurred during $HTTPD_IMG_2_0 creation"
-    exit 1
-fi
-
-# httpd with mod_proxy_cluster 1.3.x
-cd ../..
-cd mod_cluster-1.3.x/test/
-rm -rf /tmp/mod_proxy_cluster
-mkdir /tmp/mod_proxy_cluster/
-cp -r ../native ../test /tmp/mod_proxy_cluster
-cp -r /tmp/mod_proxy_cluster httpd/
-docker build -t $HTTPD_IMG_1_3 -f httpd/Containerfile httpd/
-if [ $? -ne 0 ]; then
-    echo "Error occurred during $HTTPD_IMG_1_3 creation"
-    exit 1
-fi
-cd ../..
-
+###########################
+####    C L I E N T    ####
+###########################
+echo -n "Compiling a client application... "
 cd client
 cmake . && make
 if [ $? -ne 0 ]; then
     echo "client compilation failed"
     exit 1
 fi
-cd ..
+cd $OLDPWD
+echo "Done"
 
+###########################
+###  MOD_PROXY_CLUSTER  ###
+###########################
+echo "Creating an httpd with mod_proxy_cluster container images from all directories found"
+# create a temporary directory in which we'll build the container images
+mkdir -p .tempdir
+cp Containerfile mod_proxy_cluster.conf httpd-container-run.sh .tempdir/
+for dir in mod_proxy_cluster*/
+do
+    cp -r $dir/native .tempdir/
+    cd .tempdir
+    version=$(echo $dir | sed -rn 's|mod_proxy_cluster-(.*)/|\1|p')
+    # if version is empty, it's our `mod_proxy_cluster` == 2.x version
+    version=${version:-2.x}
+    containername="mpc-perfsuite-mod_proxy_cluster-$version"
+    docker build -t $containername  -f Containerfile .
+    if [ $? -ne 0 ]; then
+        echo "Compilation of mod_proxy_cluster in $dir failed!"
+        exit 1;
+    fi
+    echo "    - $containername built from $dir"
+    cd $OLDPWD
+done
+rm -rf .tempdir
 echo "Done"
 


### PR DESCRIPTION
This PR changes naming of the container images and also the naming of mod_proxy_cluster versions (affects mostly summaries).

+ improves naming and structure of a few files and functions

close #100 